### PR TITLE
chore: Small tevm cleanups

### DIFF
--- a/packages/client/src/mud/createSystemCalls.ts
+++ b/packages/client/src/mud/createSystemCalls.ts
@@ -89,15 +89,11 @@ export function createSystemCalls(
   }
 
   const addTask = async (label: string) => {
-    const functionData = encodeFunctionData({
+    const tevmCallResult = await memoryClient.tevmContract({
+      to: worldContract.address,
       abi: worldContract.abi,
       functionName: 'app__addTask',
       args: [label],
-    })
-
-    const tevmCallResult = await memoryClient.tevmCall({
-      to: worldContract.address,
-      data: functionData,
       from: walletClient.account.address,
       throwOnFail: false,
       stateOverrideSet: precompileStateOverrideSet,
@@ -136,15 +132,11 @@ export function createSystemCalls(
   }
 
   const deleteTask = async (id: Hex) => {
-    const functionData = encodeFunctionData({
+    const tevmCallResult = await memoryClient.tevmContract({
+      to: worldContract.address,
       abi: worldContract.abi,
       functionName: 'app__deleteTask',
       args: [id],
-    })
-
-    const tevmCallResult = await memoryClient.tevmCall({
-      to: worldContract.address,
-      data: functionData,
       from: walletClient.account.address,
       throwOnFail: false,
       stateOverrideSet: precompileStateOverrideSet,

--- a/packages/client/src/mud/setupNetwork.ts
+++ b/packages/client/src/mud/setupNetwork.ts
@@ -29,6 +29,7 @@ import {
 import { transactionQueue, writeObserver } from '@latticexyz/common/actions'
 import { Subject, share } from 'rxjs'
 import { createMemoryClient } from 'tevm'
+import { createCommon, tevmDefault } from 'tevm/common'
 import { Address } from '@ethereumjs/util'
 
 /*
@@ -64,12 +65,14 @@ export async function setupNetwork() {
       blockTag: 'latest',
     },
     customPrecompiles: [storePrecompile.precompile()],
+    // a tevm common is an extension of a viem chain
+    common: createCommon(
+      networkConfig.chain,
+    )
     // loggingLevel: 'debug',
   })
 
   const publicClient = memoryClient
-  // @ts-ignore
-  publicClient.chain = networkConfig.chain
 
   const vm = await memoryClient.tevm.getVm()
   memoryClient.tevm.on('message', (data) => {


### PR DESCRIPTION
1. Use tevmContract rather than tevmCall. tevmContract is same as tevmCall with following advantages
- It will properly decode error messages
- It will return a data property of decoded data
- it abi encodes args without needing to use encodeFunctionArgs

2. Pass in the chain into tevm. Tevm calls chains common and they extend viem chains
- Generally a best practice 
- allows tevm to initialize faster since it can use the common chainId instead of fetching it
- Allows us to remove the hacky client.chain = something